### PR TITLE
Adicionando a necessidade de receber a role do usuario

### DIFF
--- a/src/main/java/br/ufrn/bora/config/dbmigrations/InitialSetupMigration.java
+++ b/src/main/java/br/ufrn/bora/config/dbmigrations/InitialSetupMigration.java
@@ -30,6 +30,8 @@ public class InitialSetupMigration {
         adminAuthority = template.save(adminAuthority);
         Authority generalUserAuthority = createAuthority(AuthoritiesConstants.GENERAL_USER);
         generalUserAuthority = template.save(generalUserAuthority);
+        Authority eventProducerAuthority = createAuthority(AuthoritiesConstants.EVENT_PRODUCER);
+        eventProducerAuthority = template.save(eventProducerAuthority);
         addUsers(userAuthority, adminAuthority);
     }
 

--- a/src/main/java/br/ufrn/bora/security/AuthoritiesConstants.java
+++ b/src/main/java/br/ufrn/bora/security/AuthoritiesConstants.java
@@ -11,6 +11,8 @@ public final class AuthoritiesConstants {
 
     public static final String GENERAL_USER = "ROLE_GENERAL_USER";
 
+    public static final String EVENT_PRODUCER = "ROLE_EVENT_PRODUCER";
+
     public static final String ANONYMOUS = "ROLE_ANONYMOUS";
 
     private AuthoritiesConstants() {}

--- a/src/main/java/br/ufrn/bora/service/UserService.java
+++ b/src/main/java/br/ufrn/bora/service/UserService.java
@@ -117,7 +117,17 @@ public class UserService {
         // new user gets registration key
         //newUser.setActivationKey(RandomUtil.generateActivationKey());
         Set<Authority> authorities = new HashSet<>();
-        authorityRepository.findById(AuthoritiesConstants.GENERAL_USER).ifPresent(authorities::add);
+
+        for (String authority : userDTO.getAuthorities()) {
+            if (!authority.equals(AuthoritiesConstants.ADMIN) && !authority.equals(AuthoritiesConstants.USER)) {
+                authorities.add(authorityRepository.findById(authority).orElseThrow(() -> new RuntimeException("Authority not found")));
+            } else {
+                throw new RuntimeException("Não é possível criar um usuário com as autoridades ADMIN ou USER");
+            }
+        }
+
+        if (authorities.isEmpty()) throw new RuntimeException("Ao menos uma autoridade válida deve ser informada");
+
         newUser.setAuthorities(authorities);
         userRepository.save(newUser);
         log.debug("Created Information for User: {}", newUser);


### PR DESCRIPTION
Adicionei a necessidade de receber a role do usuário na rota de /register e é preciso apagar o banco para rodar a classe inicial de migração pra criar a role do produtor de eventos (ROLE_EVENT_PRODUCER).

